### PR TITLE
Harden proxy with CORS, timeouts, prompt limits, and message support

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,53 @@
 # foundryVTT-MCP
+
+Railway-ready proxy service for Foundry VTT LLM workflows. This service accepts requests from a Foundry module and forwards them to OpenAI, keeping API keys on the server side.
+
+## Setup
+
+```bash
+npm install
+npm start
+```
+
+### Environment variables
+
+- `PROXY_TOKEN` (required): Shared secret that the Foundry module sends in `X-Foundry-Proxy-Token`.
+- `OPENAI_API_KEY` (required): OpenAI API key stored on the Railway service.
+- `OPENAI_BASE_URL` (optional): Override OpenAI base URL.
+- `DEFAULT_MODEL` (optional): Default model name (default: `gpt-4o-mini`).
+- `PORT` (optional): Port to listen on (default: `3000`).
+- `ALLOWED_ORIGINS` (optional): Comma-separated list of allowed browser origins for CORS.
+- `REQUEST_TIMEOUT_MS` (optional): Request timeout in ms (default: `30000`).
+- `MAX_PROMPT_CHARS` (optional): Maximum prompt size in characters (default: `8000`).
+
+## Request example
+
+```bash
+curl -X POST https://your-railway-app.up.railway.app/v1/generate \
+  -H "Content-Type: application/json" \
+  -H "X-Foundry-Proxy-Token: your-shared-token" \
+  -d '{
+    "taskType": "npc",
+    "provider": "openai",
+    "model": "gpt-4o-mini",
+    "system": "You are a helpful RPG assistant.",
+    "prompt": "Create a level 3 NPC bard with a secret.",
+    "options": {
+      "temperature": 0.7,
+      "maxTokens": 800,
+      "responseFormat": "json"
+    }
+  }'
+```
+
+## Health check
+
+```bash
+curl https://your-railway-app.up.railway.app/health
+```
+
+## Provider info
+
+```bash
+curl https://your-railway-app.up.railway.app/v1/providers
+```

--- a/package.json
+++ b/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "foundryvtt-mcp-proxy",
+  "version": "0.2.0",
+  "description": "Railway-ready proxy for Foundry VTT LLM workflows",
+  "main": "src/index.js",
+  "scripts": {
+    "start": "node src/index.js"
+  },
+  "engines": {
+    "node": ">=18"
+  },
+  "dependencies": {
+    "cors": "^2.8.5",
+    "express": "^4.19.2"
+  }
+}

--- a/src/index.js
+++ b/src/index.js
@@ -1,0 +1,183 @@
+const express = require("express");
+const cors = require("cors");
+
+const app = express();
+app.use(express.json({ limit: "2mb" }));
+
+const {
+  PORT = 3000,
+  PROXY_TOKEN,
+  OPENAI_API_KEY,
+  OPENAI_BASE_URL = "https://api.openai.com/v1",
+  DEFAULT_MODEL = "gpt-4o-mini",
+  ALLOWED_ORIGINS,
+  REQUEST_TIMEOUT_MS = 30000,
+  MAX_PROMPT_CHARS = 8000
+} = process.env;
+
+const allowedProviders = new Set(["openai"]);
+
+const corsOptions = (() => {
+  if (!ALLOWED_ORIGINS) {
+    return { origin: true };
+  }
+  const allowed = new Set(
+    ALLOWED_ORIGINS.split(",")
+      .map((value) => value.trim())
+      .filter(Boolean)
+  );
+  return {
+    origin(origin, callback) {
+      if (!origin || allowed.has(origin)) {
+        callback(null, true);
+        return;
+      }
+      callback(new Error("Origin not allowed by CORS"));
+    }
+  };
+})();
+
+app.use(cors(corsOptions));
+
+function assertAuth(req, res) {
+  if (!PROXY_TOKEN) {
+    res.status(500).json({ error: "Missing PROXY_TOKEN on server." });
+    return false;
+  }
+  const token = req.get("X-Foundry-Proxy-Token");
+  if (!token || token !== PROXY_TOKEN) {
+    res.status(401).json({ error: "Unauthorized." });
+    return false;
+  }
+  return true;
+}
+
+function normalizeMessages({ messages, system, prompt }) {
+  if (Array.isArray(messages) && messages.length > 0) {
+    const normalized = messages
+      .filter((message) => message && typeof message === "object")
+      .map(({ role, content }) => ({ role, content }))
+      .filter(
+        ({ role, content }) =>
+          typeof role === "string" && typeof content === "string"
+      );
+    return normalized.length > 0 ? normalized : null;
+  }
+
+  if (!prompt || typeof prompt !== "string") {
+    return null;
+  }
+
+  return [
+    system ? { role: "system", content: system } : null,
+    { role: "user", content: prompt }
+  ].filter(Boolean);
+}
+
+app.get("/health", (req, res) => {
+  res.json({ status: "ok" });
+});
+
+app.get("/v1/providers", (req, res) => {
+  res.json({
+    providers: Array.from(allowedProviders),
+    defaultProvider: "openai",
+    defaultModel: DEFAULT_MODEL
+  });
+});
+
+app.post("/v1/generate", async (req, res) => {
+  if (!assertAuth(req, res)) return;
+
+  const {
+    provider = "openai",
+    model = DEFAULT_MODEL,
+    prompt,
+    system,
+    messages,
+    options = {},
+    taskType,
+    clientId
+  } = req.body ?? {};
+
+  const formattedMessages = normalizeMessages({ messages, system, prompt });
+
+  if (!formattedMessages) {
+    res.status(400).json({ error: "prompt or messages are required." });
+    return;
+  }
+
+  const promptContent = formattedMessages
+    .map((message) => message.content)
+    .join("\n");
+  if (promptContent.length > Number(MAX_PROMPT_CHARS)) {
+    res.status(400).json({ error: "prompt exceeds MAX_PROMPT_CHARS." });
+    return;
+  }
+
+  if (!allowedProviders.has(provider)) {
+    res.status(400).json({ error: `Unsupported provider: ${provider}.` });
+    return;
+  }
+
+  if (!OPENAI_API_KEY) {
+    res.status(500).json({ error: "Missing OPENAI_API_KEY on server." });
+    return;
+  }
+
+  const controller = new AbortController();
+  const timeout = setTimeout(
+    () => controller.abort(),
+    Number(REQUEST_TIMEOUT_MS)
+  );
+
+  try {
+    const response = await fetch(`${OPENAI_BASE_URL}/chat/completions`, {
+      method: "POST",
+      headers: {
+        Authorization: `Bearer ${OPENAI_API_KEY}`,
+        "Content-Type": "application/json"
+      },
+      body: JSON.stringify({
+        model,
+        messages: formattedMessages,
+        temperature: options.temperature ?? 0.7,
+        max_tokens: options.maxTokens ?? 800,
+        top_p: options.topP ?? 1,
+        presence_penalty: options.presencePenalty ?? 0,
+        frequency_penalty: options.frequencyPenalty ?? 0,
+        response_format:
+          options.responseFormat === "json"
+            ? { type: "json_object" }
+            : undefined,
+        user: clientId || undefined,
+        metadata: taskType ? { taskType } : undefined
+      }),
+      signal: controller.signal
+    });
+
+    if (!response.ok) {
+      const errorText = await response.text();
+      res.status(response.status).json({ error: errorText });
+      return;
+    }
+
+    const data = await response.json();
+    const content = data.choices?.[0]?.message?.content ?? "";
+
+    res.json({
+      content,
+      usage: data.usage ?? null,
+      model: data.model ?? model
+    });
+  } catch (error) {
+    const status = error.name === "AbortError" ? 504 : 500;
+    res.status(status).json({ error: error.message });
+  } finally {
+    clearTimeout(timeout);
+  }
+});
+
+app.listen(PORT, () => {
+  console.log(`Foundry proxy listening on ${PORT}`);
+});


### PR DESCRIPTION
### Motivation
- Provide a more secure and robust Railway-ready proxy so Foundry modules can route LLM requests without exposing API keys and with centralized controls. 
- Enforce token-based authentication and CORS origin controls to limit client access to the proxy. 
- Add request safety (timeouts and prompt-size limits) and support structured messages to reduce malformed requests and server load.

### Description
- Add an Express server in `src/index.js` exposing `GET /health`, `GET /v1/providers`, and `POST /v1/generate` with authentication via `X-Foundry-Proxy-Token` and environment-configured `PROXY_TOKEN` and `OPENAI_API_KEY`.
- Implement CORS configuration driven by `ALLOWED_ORIGINS`, request timeouts using `AbortController` and `REQUEST_TIMEOUT_MS`, and prompt-size limiting via `MAX_PROMPT_CHARS`.
- Add message normalization (accept either `messages` array or `system`+`prompt`), map request `options` into the OpenAI `chat/completions` payload, and forward `user`/`metadata` fields; return `content`, `usage`, and `model` in responses.
- Update `package.json` with `cors` and `express` dependencies and a `start` script, and expand `README.md` with setup, env variables, and usage examples.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69866b91d8948330bc5547b7e520e6c1)