### PR TITLE
Add MCP server for vault reading and Foundry payload generation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+node_modules/
+mcp-server/dist/
+.DS_Store

--- a/docs/handoff-foundry-mcp-switchboard.md
+++ b/docs/handoff-foundry-mcp-switchboard.md
@@ -1,0 +1,181 @@
+# Handoff: Foundry MCP Server + Switchboard Integration
+
+**Goal:** Wire the Foundry VTT MCP server into the OpenClaw MCP switchboard so that a Claude Code session can read Obsidian Honkonomicon vault notes and create them as journal entries in Foundry on The Forge.
+
+---
+
+## Current State (verified 2026-04-21)
+
+### What exists
+
+| Component | Path | Status |
+|---|---|---|
+| REST proxy (OpenAI relay) | `foundryVTT-MCP/src/index.js` | Exists, Express, port 3000 |
+| Foundry module (client) | `foundryVTT-MCP/foundry-mcp/` | Exists, installed in Forge world |
+| Obsidian vault scanner | `foundryVTT-MCP/obsidian-agent/src/index.js` | Exists, Express, port 8790 |
+| MCP switchboard | `~/Documents/Codex/mcp-switchboard/` | Live, routing 6 servers |
+| Honkonomicon vault | `~/Documents/Obsidian/Honkonomicon/` | Exists, structured |
+
+### What does NOT exist
+
+- An MCP server (Model Context Protocol) for Foundry — **this is the missing piece**
+- A "push to Foundry" pathway — current architecture is **Foundry pulls** from the proxy
+- `foundry` entry in `~/.config/opencode/opencode.json`
+- `foundry` in `SWITCHBOARD_INCLUDE` in `~/.openclaw/openclaw.json`
+
+---
+
+## Architecture
+
+### Current flow (Foundry pulls)
+```
+Foundry module → HTTP POST /v1/payload → obsidian-agent → returns JSON → Foundry imports
+```
+
+### Target flow (MCP pushes)
+```
+Claude (via switchboard) → foundry MCP server → Forge REST API → creates JournalEntry in world
+```
+
+The new MCP server is a **push** model: it uses The Forge's REST API to create documents directly, rather than waiting for Foundry to pull.
+
+---
+
+## What Needs to Be Built
+
+### 1. New MCP server: `foundryVTT-MCP/mcp-server/`
+
+A Node.js service using `@modelcontextprotocol/sdk` (stdio transport) that exposes these tools:
+
+#### Tool: `foundry_read_obsidian_notes`
+- Input: `paths` (string[], optional), `filter_type` (string, optional: `"journal"`, `"actor"`, etc.)
+- Behavior: reads `.md` files from `~/Documents/Obsidian/Honkonomicon/`, parses frontmatter, returns file list with content
+- Implementation: reuse logic from `obsidian-agent/src/index.js` (gray-matter, walkVaultFiles) — but as a function, not HTTP
+
+#### Tool: `foundry_create_journal_entries`
+- Input: `documents` (array of `{ name, content, folder? }`)
+- Behavior: calls The Forge REST API to create JournalEntry documents in the active world
+- Returns: created document IDs
+
+#### Tool: `foundry_list_journals`
+- Input: none
+- Behavior: queries Forge API for existing JournalEntry list in world
+- Returns: array of `{ id, name }`
+
+### 2. Forge API connectivity
+
+The Forge exposes Foundry's REST API at:
+```
+https://forge-vtt.com/api/
+```
+or via the game URL (e.g., `https://{userId}.forge-vtt.com`).
+
+**Auth:** The Forge API key — check 1Password (Tantalus vault). If not there, generate one at forge-vtt.com → Account → API Key.
+
+Foundry v13 REST API endpoints used:
+- `POST /api/document/JournalEntry` — create journal entry
+- `GET /api/document/JournalEntry` — list journal entries
+
+The `foundry-mcp` module (already installed in the world) exposes `window.FoundryMCP.importPayload()` as a fallback but the REST API is the cleaner path from outside.
+
+### 3. Register in opencode.json
+
+Add to `~/.config/opencode/opencode.json` under `mcp`:
+
+```json
+"foundry": {
+  "command": ["node", "/Users/benjaminreynolds/Documents/Codex/foundryVTT-MCP/mcp-server/dist/server.js"],
+  "enabled": true,
+  "environment": {
+    "FORGE_API_KEY": "op://Tantalus/The Forge/api_key",
+    "FORGE_GAME_URL": "op://Tantalus/The Forge/game_url"
+  },
+  "type": "local"
+}
+```
+
+### 4. Add to switchboard SWITCHBOARD_INCLUDE
+
+In `~/.openclaw/openclaw.json`, update the `mcp-switchboard` entry:
+```
+"SWITCHBOARD_INCLUDE": "context7,fabric-lakehouse-files,foundry,google-mcp,mgrep,pencil,powerbi-semantic-model"
+```
+
+Same update in `~/.config/opencode/opencode.json` → `mcp.mcp-switchboard.environment.SWITCHBOARD_INCLUDE`.
+
+---
+
+## Honkonomicon Vault Structure
+
+```
+~/Documents/Obsidian/Honkonomicon/
+├── 00_Campaign/
+├── 00_System/
+├── 01_Sessions/
+├── 02_PCs/
+├── 03_NPCs/
+├── 04_Locations/
+├── 05_Factions/
+├── 06_Quests/
+├── 07_Items/
+├── 08_Monsters/
+├── 09_Rules/
+├── 10_Maps_Assets/
+├── 11_Reference/
+├── AGENTS.md
+└── MEMORY.md
+```
+
+Notes use standard Markdown with optional YAML frontmatter. The obsidian-agent already maps frontmatter `type:` to Foundry document types.
+
+---
+
+## Implementation Plan
+
+**Repo:** `~/Documents/Codex/foundryVTT-MCP/`  
+**New directory:** `mcp-server/`
+
+```
+mcp-server/
+  package.json          (@modelcontextprotocol/sdk, node-fetch)
+  src/
+    server.ts           entry point, stdio MCP server
+    tools/
+      readObsidian.ts   read vault notes (port logic from obsidian-agent)
+      createJournals.ts push to Forge REST API
+      listJournals.ts   query Forge REST API
+    forge-api.ts        thin wrapper for Forge REST calls (auth, base URL)
+  tsconfig.json
+  dist/                 compiled output
+```
+
+**Build command:** `npm run build` → `tsc`  
+**Run command:** `node dist/server.js` (stdio, no port)
+
+---
+
+## Pre-flight Checklist for the Implementing Session
+
+- [ ] Confirm The Forge API key is in 1Password (Tantalus vault → "The Forge")
+- [ ] Confirm `foundry-mcp` module is enabled in the active Forge world
+- [ ] Confirm Foundry v13 REST API is accessible (test: `GET {game_url}/api/` with API key)
+- [ ] Build and smoke-test the MCP server locally before registering
+- [ ] After registration, run `switchboard.search("foundry")` to verify routing
+
+---
+
+## 1Password References
+
+- Forge API key: look for "The Forge" or "forge-vtt.com" in Tantalus vault
+- Proxy token: `foundryVTT-MCP` project uses `PROXY_TOKEN` — may be in Tantalus vault as well
+
+---
+
+## Related Files
+
+- `foundryVTT-MCP/AGENTS.md` — project governance
+- `foundryVTT-MCP/obsidian-agent/src/index.js` — vault walker logic to reuse
+- `foundryVTT-MCP/foundry-mcp/scripts/foundry-mcp.js` — module API surface (importPayload pattern)
+- `~/.config/opencode/opencode.json` — MCP registry
+- `~/.openclaw/openclaw.json` — OpenClaw MCP config + SWITCHBOARD_INCLUDE
+- `~/Documents/Codex/mcp-switchboard/` — switchboard source (reference for how other servers are registered)

--- a/mcp-server/package-lock.json
+++ b/mcp-server/package-lock.json
@@ -1,0 +1,1299 @@
+{
+  "name": "foundry-mcp-server",
+  "version": "0.1.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "foundry-mcp-server",
+      "version": "0.1.0",
+      "dependencies": {
+        "@modelcontextprotocol/sdk": "^1.17.4",
+        "gray-matter": "^4.0.3",
+        "marked": "^18.0.2",
+        "zod": "^4.1.5"
+      },
+      "devDependencies": {
+        "@types/node": "^24.3.1",
+        "typescript": "^5.9.2"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@hono/node-server": {
+      "version": "1.19.14",
+      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-1.19.14.tgz",
+      "integrity": "sha512-GwtvgtXxnWsucXvbQXkRgqksiH2Qed37H9xHZocE5sA3N8O8O8/8FA3uclQXxXVzc9XBZuEOMK7+r02FmSpHtw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.14.1"
+      },
+      "peerDependencies": {
+        "hono": "^4"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk": {
+      "version": "1.29.0",
+      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.29.0.tgz",
+      "integrity": "sha512-zo37mZA9hJWpULgkRpowewez1y6ML5GsXJPY8FI0tBBCd77HEvza4jDqRKOXgHNn867PVGCyTdzqpz0izu5ZjQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@hono/node-server": "^1.19.9",
+        "ajv": "^8.17.1",
+        "ajv-formats": "^3.0.1",
+        "content-type": "^1.0.5",
+        "cors": "^2.8.5",
+        "cross-spawn": "^7.0.5",
+        "eventsource": "^3.0.2",
+        "eventsource-parser": "^3.0.0",
+        "express": "^5.2.1",
+        "express-rate-limit": "^8.2.1",
+        "hono": "^4.11.4",
+        "jose": "^6.1.3",
+        "json-schema-typed": "^8.0.2",
+        "pkce-challenge": "^5.0.0",
+        "raw-body": "^3.0.0",
+        "zod": "^3.25 || ^4.0",
+        "zod-to-json-schema": "^3.25.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@cfworker/json-schema": "^4.1.1",
+        "zod": "^3.25 || ^4.0"
+      },
+      "peerDependenciesMeta": {
+        "@cfworker/json-schema": {
+          "optional": true
+        },
+        "zod": {
+          "optional": false
+        }
+      }
+    },
+    "node_modules/@types/node": {
+      "version": "24.12.2",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.12.2.tgz",
+      "integrity": "sha512-A1sre26ke7HDIuY/M23nd9gfB+nrmhtYyMINbjI1zHJxYteKR6qSMX56FsmjMcDb3SMcjJg5BiRRgOCC/yBD0g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~7.16.0"
+      }
+    },
+    "node_modules/accepts": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/accepts/-/accepts-2.0.0.tgz",
+      "integrity": "sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-types": "^3.0.0",
+        "negotiator": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/ajv": {
+      "version": "8.18.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.18.0.tgz",
+      "integrity": "sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==",
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3",
+        "fast-uri": "^3.0.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/ajv-formats": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-3.0.1.tgz",
+      "integrity": "sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ==",
+      "license": "MIT",
+      "dependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "ajv": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/argparse": {
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
+      "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
+      "license": "MIT",
+      "dependencies": {
+        "sprintf-js": "~1.0.2"
+      }
+    },
+    "node_modules/body-parser": {
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-2.2.2.tgz",
+      "integrity": "sha512-oP5VkATKlNwcgvxi0vM0p/D3n2C3EReYVX+DNYs5TjZFn/oQt2j+4sVJtSMr18pdRr8wjTcBl6LoV+FUwzPmNA==",
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "^3.1.2",
+        "content-type": "^1.0.5",
+        "debug": "^4.4.3",
+        "http-errors": "^2.0.0",
+        "iconv-lite": "^0.7.0",
+        "on-finished": "^2.4.1",
+        "qs": "^6.14.1",
+        "raw-body": "^3.0.1",
+        "type-is": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/bytes": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.2.tgz",
+      "integrity": "sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/call-bind-apply-helpers": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
+      "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/call-bound": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/call-bound/-/call-bound-1.0.4.tgz",
+      "integrity": "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "get-intrinsic": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/content-disposition": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-1.1.0.tgz",
+      "integrity": "sha512-5jRCH9Z/+DRP7rkvY83B+yGIGX96OYdJmzngqnw2SBSxqCFPd0w2km3s5iawpGX8krnwSGmF0FW5Nhr0Hfai3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/content-type": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.5.tgz",
+      "integrity": "sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/cookie": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.2.tgz",
+      "integrity": "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/cookie-signature": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.2.2.tgz",
+      "integrity": "sha512-D76uU73ulSXrD1UXF4KE2TMxVVwhsnCgfAyTg9k8P6KGZjlXKrOLe4dJQKI3Bxi5wjesZoFXJWElNWBjPZMbhg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.6.0"
+      }
+    },
+    "node_modules/cors": {
+      "version": "2.8.6",
+      "resolved": "https://registry.npmjs.org/cors/-/cors-2.8.6.tgz",
+      "integrity": "sha512-tJtZBBHA6vjIAaF6EnIaq6laBBP9aq/Y3ouVJjEfoHbRBcHBAHYcMh/w8LDrk2PvIMMq8gmopa5D4V8RmbrxGw==",
+      "license": "MIT",
+      "dependencies": {
+        "object-assign": "^4",
+        "vary": "^1"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/cross-spawn": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+      "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
+      "license": "MIT",
+      "dependencies": {
+        "path-key": "^3.1.0",
+        "shebang-command": "^2.0.0",
+        "which": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/depd": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
+      "integrity": "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/dunder-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
+      "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/ee-first": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
+      "integrity": "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==",
+      "license": "MIT"
+    },
+    "node_modules/encodeurl": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-2.0.0.tgz",
+      "integrity": "sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/es-define-property": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
+      "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-errors": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
+      "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-object-atoms": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
+      "integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/escape-html": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
+      "integrity": "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==",
+      "license": "MIT"
+    },
+    "node_modules/esprima": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
+      "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
+      "license": "BSD-2-Clause",
+      "bin": {
+        "esparse": "bin/esparse.js",
+        "esvalidate": "bin/esvalidate.js"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/etag": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
+      "integrity": "sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/eventsource": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/eventsource/-/eventsource-3.0.7.tgz",
+      "integrity": "sha512-CRT1WTyuQoD771GW56XEZFQ/ZoSfWid1alKGDYMmkt2yl8UXrVR4pspqWNEcqKvVIzg6PAltWjxcSSPrboA4iA==",
+      "license": "MIT",
+      "dependencies": {
+        "eventsource-parser": "^3.0.1"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/eventsource-parser": {
+      "version": "3.0.8",
+      "resolved": "https://registry.npmjs.org/eventsource-parser/-/eventsource-parser-3.0.8.tgz",
+      "integrity": "sha512-70QWGkr4snxr0OXLRWsFLeRBIRPuQOvt4s8QYjmUlmlkyTZkRqS7EDVRZtzU3TiyDbXSzaOeF0XUKy8PchzukQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/express": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/express/-/express-5.2.1.tgz",
+      "integrity": "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==",
+      "license": "MIT",
+      "dependencies": {
+        "accepts": "^2.0.0",
+        "body-parser": "^2.2.1",
+        "content-disposition": "^1.0.0",
+        "content-type": "^1.0.5",
+        "cookie": "^0.7.1",
+        "cookie-signature": "^1.2.1",
+        "debug": "^4.4.0",
+        "depd": "^2.0.0",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "etag": "^1.8.1",
+        "finalhandler": "^2.1.0",
+        "fresh": "^2.0.0",
+        "http-errors": "^2.0.0",
+        "merge-descriptors": "^2.0.0",
+        "mime-types": "^3.0.0",
+        "on-finished": "^2.4.1",
+        "once": "^1.4.0",
+        "parseurl": "^1.3.3",
+        "proxy-addr": "^2.0.7",
+        "qs": "^6.14.0",
+        "range-parser": "^1.2.1",
+        "router": "^2.2.0",
+        "send": "^1.1.0",
+        "serve-static": "^2.2.0",
+        "statuses": "^2.0.1",
+        "type-is": "^2.0.1",
+        "vary": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/express-rate-limit": {
+      "version": "8.3.2",
+      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.3.2.tgz",
+      "integrity": "sha512-77VmFeJkO0/rvimEDuUC5H30oqUC4EyOhyGccfqoLebB0oiEYfM7nwPrsDsBL1gsTpwfzX8SFy2MT3TDyRq+bg==",
+      "license": "MIT",
+      "dependencies": {
+        "ip-address": "10.1.0"
+      },
+      "engines": {
+        "node": ">= 16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/express-rate-limit"
+      },
+      "peerDependencies": {
+        "express": ">= 4.11"
+      }
+    },
+    "node_modules/extend-shallow": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+      "integrity": "sha512-zCnTtlxNoAiDc3gqY2aYAWFx7XWWiasuF2K8Me5WbN8otHKTUKBwjPtNpRs/rbUZm7KxWAaNj7P1a/p52GbVug==",
+      "license": "MIT",
+      "dependencies": {
+        "is-extendable": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/fast-deep-equal": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+      "license": "MIT"
+    },
+    "node_modules/fast-uri": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.0.tgz",
+      "integrity": "sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/finalhandler": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-2.1.1.tgz",
+      "integrity": "sha512-S8KoZgRZN+a5rNwqTxlZZePjT/4cnm0ROV70LedRHZ0p8u9fRID0hJUZQpkKLzro8LfmC8sx23bY6tVNxv8pQA==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.0",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "on-finished": "^2.4.1",
+        "parseurl": "^1.3.3",
+        "statuses": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 18.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/forwarded": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.2.0.tgz",
+      "integrity": "sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/fresh": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/fresh/-/fresh-2.0.0.tgz",
+      "integrity": "sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/function-bind": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+      "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-intrinsic": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
+      "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "es-define-property": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.1.1",
+        "function-bind": "^1.1.2",
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "has-symbols": "^1.1.0",
+        "hasown": "^2.0.2",
+        "math-intrinsics": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
+      "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
+      "license": "MIT",
+      "dependencies": {
+        "dunder-proto": "^1.0.1",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/gopd": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
+      "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/gray-matter": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/gray-matter/-/gray-matter-4.0.3.tgz",
+      "integrity": "sha512-5v6yZd4JK3eMI3FqqCouswVqwugaA9r4dNZB1wwcmrD02QkV5H0y7XBQW8QwQqEaZY1pM9aqORSORhJRdNK44Q==",
+      "license": "MIT",
+      "dependencies": {
+        "js-yaml": "^3.13.1",
+        "kind-of": "^6.0.2",
+        "section-matter": "^1.0.0",
+        "strip-bom-string": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=6.0"
+      }
+    },
+    "node_modules/has-symbols": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
+      "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/hasown": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.3.tgz",
+      "integrity": "sha512-ej4AhfhfL2Q2zpMmLo7U1Uv9+PyhIZpgQLGT1F9miIGmiCJIoCgSmczFdrc97mWT4kVY72KA+WnnhJ5pghSvSg==",
+      "license": "MIT",
+      "dependencies": {
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/hono": {
+      "version": "4.12.14",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.14.tgz",
+      "integrity": "sha512-am5zfg3yu6sqn5yjKBNqhnTX7Cv+m00ox+7jbaKkrLMRJ4rAdldd1xPd/JzbBWspqaQv6RSTrgFN95EsfhC+7w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=16.9.0"
+      }
+    },
+    "node_modules/http-errors": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.1.tgz",
+      "integrity": "sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==",
+      "license": "MIT",
+      "dependencies": {
+        "depd": "~2.0.0",
+        "inherits": "~2.0.4",
+        "setprototypeof": "~1.2.0",
+        "statuses": "~2.0.2",
+        "toidentifier": "~1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/iconv-lite": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.7.2.tgz",
+      "integrity": "sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw==",
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/inherits": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "license": "ISC"
+    },
+    "node_modules/ip-address": {
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.1.0.tgz",
+      "integrity": "sha512-XXADHxXmvT9+CRxhXg56LJovE+bmWnEWB78LB83VZTprKTmaC5QfruXocxzTZ2Kl0DNwKuBdlIhjL8LeY8Sf8Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 12"
+      }
+    },
+    "node_modules/ipaddr.js": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.1.tgz",
+      "integrity": "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/is-extendable": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-0.1.1.tgz",
+      "integrity": "sha512-5BMULNob1vgFX6EjQw5izWDxrecWK9AM72rugNr0TFldMOi0fj6Jk+zeKIt0xGj4cEfQIJth4w3OKWOJ4f+AFw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-promise": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-4.0.0.tgz",
+      "integrity": "sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ==",
+      "license": "MIT"
+    },
+    "node_modules/isexe": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
+      "license": "ISC"
+    },
+    "node_modules/jose": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/jose/-/jose-6.2.2.tgz",
+      "integrity": "sha512-d7kPDd34KO/YnzaDOlikGpOurfF0ByC2sEV4cANCtdqLlTfBlw2p14O/5d/zv40gJPbIQxfES3nSx1/oYNyuZQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/panva"
+      }
+    },
+    "node_modules/js-yaml": {
+      "version": "3.14.2",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.2.tgz",
+      "integrity": "sha512-PMSmkqxr106Xa156c2M265Z+FTrPl+oxd/rgOQy2tijQeK5TxQ43psO1ZCwhVOSdnn+RzkzlRz/eY4BgJBYVpg==",
+      "license": "MIT",
+      "dependencies": {
+        "argparse": "^1.0.7",
+        "esprima": "^4.0.0"
+      },
+      "bin": {
+        "js-yaml": "bin/js-yaml.js"
+      }
+    },
+    "node_modules/json-schema-traverse": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+      "license": "MIT"
+    },
+    "node_modules/json-schema-typed": {
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/json-schema-typed/-/json-schema-typed-8.0.2.tgz",
+      "integrity": "sha512-fQhoXdcvc3V28x7C7BMs4P5+kNlgUURe2jmUT1T//oBRMDrqy1QPelJimwZGo7Hg9VPV3EQV5Bnq4hbFy2vetA==",
+      "license": "BSD-2-Clause"
+    },
+    "node_modules/kind-of": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.3.tgz",
+      "integrity": "sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/marked": {
+      "version": "18.0.2",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-18.0.2.tgz",
+      "integrity": "sha512-NsmlUYBS/Zg57rgDWMYdnre6OTj4e+qq/JS2ot3KrYLSoHLw+sDu0Nm1ZGpRgYAq6c+b1ekaY5NzVchMCQnzcg==",
+      "license": "MIT",
+      "bin": {
+        "marked": "bin/marked.js"
+      },
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/math-intrinsics": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
+      "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/media-typer": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-1.1.0.tgz",
+      "integrity": "sha512-aisnrDP4GNe06UcKFnV5bfMNPBUw4jsLGaWwWfnH3v02GnBuXX2MCVn5RbrWo0j3pczUilYblq7fQ7Nw2t5XKw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/merge-descriptors": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-2.0.0.tgz",
+      "integrity": "sha512-Snk314V5ayFLhp3fkUREub6WtjBfPdCPY1Ln8/8munuLuiYhsABgBVWsozAG+MWMbVEvcdcpbi9R7ww22l9Q3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/mime-db": {
+      "version": "1.54.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.54.0.tgz",
+      "integrity": "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime-types": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-3.0.2.tgz",
+      "integrity": "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "^1.54.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "license": "MIT"
+    },
+    "node_modules/negotiator": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-1.0.0.tgz",
+      "integrity": "sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/object-assign": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+      "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/object-inspect": {
+      "version": "1.13.4",
+      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.4.tgz",
+      "integrity": "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/on-finished": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.4.1.tgz",
+      "integrity": "sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==",
+      "license": "MIT",
+      "dependencies": {
+        "ee-first": "1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
+      "license": "ISC",
+      "dependencies": {
+        "wrappy": "1"
+      }
+    },
+    "node_modules/parseurl": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
+      "integrity": "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/path-key": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+      "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/path-to-regexp": {
+      "version": "8.4.2",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.4.2.tgz",
+      "integrity": "sha512-qRcuIdP69NPm4qbACK+aDogI5CBDMi1jKe0ry5rSQJz8JVLsC7jV8XpiJjGRLLol3N+R5ihGYcrPLTno6pAdBA==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/pkce-challenge": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/pkce-challenge/-/pkce-challenge-5.0.1.tgz",
+      "integrity": "sha512-wQ0b/W4Fr01qtpHlqSqspcj3EhBvimsdh0KlHhH8HRZnMsEa0ea2fTULOXOS9ccQr3om+GcGRk4e+isrZWV8qQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/proxy-addr": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.7.tgz",
+      "integrity": "sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==",
+      "license": "MIT",
+      "dependencies": {
+        "forwarded": "0.2.0",
+        "ipaddr.js": "1.9.1"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/qs": {
+      "version": "6.15.1",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.1.tgz",
+      "integrity": "sha512-6YHEFRL9mfgcAvql/XhwTvf5jKcOiiupt2FiJxHkiX1z4j7WL8J/jRHYLluORvc1XxB5rV20KoeK00gVJamspg==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "side-channel": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=0.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/range-parser": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.1.tgz",
+      "integrity": "sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/raw-body": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-3.0.2.tgz",
+      "integrity": "sha512-K5zQjDllxWkf7Z5xJdV0/B0WTNqx6vxG70zJE4N0kBs4LovmEYWJzQGxC9bS9RAKu3bgM40lrd5zoLJ12MQ5BA==",
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "~3.1.2",
+        "http-errors": "~2.0.1",
+        "iconv-lite": "~0.7.0",
+        "unpipe": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/require-from-string": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/router": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/router/-/router-2.2.0.tgz",
+      "integrity": "sha512-nLTrUKm2UyiL7rlhapu/Zl45FwNgkZGaCpZbIHajDYgwlJCOzLSk+cIPAnsEqV955GjILJnKbdQC1nVPz+gAYQ==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.0",
+        "depd": "^2.0.0",
+        "is-promise": "^4.0.0",
+        "parseurl": "^1.3.3",
+        "path-to-regexp": "^8.0.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/safer-buffer": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+      "license": "MIT"
+    },
+    "node_modules/section-matter": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/section-matter/-/section-matter-1.0.0.tgz",
+      "integrity": "sha512-vfD3pmTzGpufjScBh50YHKzEu2lxBWhVEHsNGoEXmCmn2hKGfeNLYMzCJpe8cD7gqX7TJluOVpBkAequ6dgMmA==",
+      "license": "MIT",
+      "dependencies": {
+        "extend-shallow": "^2.0.1",
+        "kind-of": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/send": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/send/-/send-1.2.1.tgz",
+      "integrity": "sha512-1gnZf7DFcoIcajTjTwjwuDjzuz4PPcY2StKPlsGAQ1+YH20IRVrBaXSWmdjowTJ6u8Rc01PoYOGHXfP1mYcZNQ==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.3",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "etag": "^1.8.1",
+        "fresh": "^2.0.0",
+        "http-errors": "^2.0.1",
+        "mime-types": "^3.0.2",
+        "ms": "^2.1.3",
+        "on-finished": "^2.4.1",
+        "range-parser": "^1.2.1",
+        "statuses": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/serve-static": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-2.2.1.tgz",
+      "integrity": "sha512-xRXBn0pPqQTVQiC8wyQrKs2MOlX24zQ0POGaj0kultvoOCstBQM5yvOhAVSUwOMjQtTvsPWoNCHfPGwaaQJhTw==",
+      "license": "MIT",
+      "dependencies": {
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "parseurl": "^1.3.3",
+        "send": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/setprototypeof": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz",
+      "integrity": "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==",
+      "license": "ISC"
+    },
+    "node_modules/shebang-command": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+      "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+      "license": "MIT",
+      "dependencies": {
+        "shebang-regex": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/shebang-regex": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+      "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/side-channel": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.0.tgz",
+      "integrity": "sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.3",
+        "side-channel-list": "^1.0.0",
+        "side-channel-map": "^1.0.1",
+        "side-channel-weakmap": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-list": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.1.tgz",
+      "integrity": "sha512-mjn/0bi/oUURjc5Xl7IaWi/OJJJumuoJFQJfDDyO46+hBWsfaVM65TBHq2eoZBhzl9EchxOijpkbRC8SVBQU0w==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.4"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-map": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-map/-/side-channel-map-1.0.1.tgz",
+      "integrity": "sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-weakmap": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/side-channel-weakmap/-/side-channel-weakmap-1.0.2.tgz",
+      "integrity": "sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3",
+        "side-channel-map": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/sprintf-js": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
+      "integrity": "sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/statuses": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.2.tgz",
+      "integrity": "sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/strip-bom-string": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/strip-bom-string/-/strip-bom-string-1.0.0.tgz",
+      "integrity": "sha512-uCC2VHvQRYu+lMh4My/sFNmF2klFymLX1wHJeXnbEJERpV/ZsVuonzerjfrGpIGF7LBVa1O7i9kjiWvJiFck8g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/toidentifier": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.1.tgz",
+      "integrity": "sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.6"
+      }
+    },
+    "node_modules/type-is": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/type-is/-/type-is-2.0.1.tgz",
+      "integrity": "sha512-OZs6gsjF4vMp32qrCbiVSkrFmXtG/AZhY3t0iAMrMBiAZyV9oALtXO8hsrHbMXF9x6L3grlFuwW2oAz7cav+Gw==",
+      "license": "MIT",
+      "dependencies": {
+        "content-type": "^1.0.5",
+        "media-typer": "^1.1.0",
+        "mime-types": "^3.0.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "7.16.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.16.0.tgz",
+      "integrity": "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/unpipe": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
+      "integrity": "sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/vary": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
+      "integrity": "sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/which": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+      "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+      "license": "ISC",
+      "dependencies": {
+        "isexe": "^2.0.0"
+      },
+      "bin": {
+        "node-which": "bin/node-which"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
+      "license": "ISC"
+    },
+    "node_modules/zod": {
+      "version": "4.3.6",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-4.3.6.tgz",
+      "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
+    },
+    "node_modules/zod-to-json-schema": {
+      "version": "3.25.2",
+      "resolved": "https://registry.npmjs.org/zod-to-json-schema/-/zod-to-json-schema-3.25.2.tgz",
+      "integrity": "sha512-O/PgfnpT1xKSDeQYSCfRI5Gy3hPf91mKVDuYLUHZJMiDFptvP41MSnWofm8dnCm0256ZNfZIM7DSzuSMAFnjHA==",
+      "license": "ISC",
+      "peerDependencies": {
+        "zod": "^3.25.28 || ^4"
+      }
+    }
+  }
+}

--- a/mcp-server/package.json
+++ b/mcp-server/package.json
@@ -1,0 +1,23 @@
+{
+  "name": "foundry-mcp-server",
+  "version": "0.1.0",
+  "type": "module",
+  "main": "dist/server.js",
+  "scripts": {
+    "build": "tsc",
+    "start": "node dist/server.js"
+  },
+  "dependencies": {
+    "@modelcontextprotocol/sdk": "^1.17.4",
+    "gray-matter": "^4.0.3",
+    "marked": "^18.0.2",
+    "zod": "^4.1.5"
+  },
+  "devDependencies": {
+    "@types/node": "^24.3.1",
+    "typescript": "^5.9.2"
+  },
+  "engines": {
+    "node": ">=18"
+  }
+}

--- a/mcp-server/src/server.ts
+++ b/mcp-server/src/server.ts
@@ -1,0 +1,60 @@
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
+
+import { readObsidianSchema, readObsidianNotes } from "./tools/readObsidian.js";
+import { createJournalsSchema, buildImportPayload } from "./tools/createJournals.js";
+import { listJournalsSchema, LIST_JOURNALS_UNAVAILABLE } from "./tools/listJournals.js";
+
+const VAULT_PATH = process.env.VAULT_PATH || "";
+const MAX_FILES = parseInt(process.env.MAX_FILES || "500", 10);
+const MAX_CONTENT_CHARS = parseInt(process.env.MAX_CONTENT_CHARS || "20000", 10);
+
+const server = new McpServer({
+  name: "foundry-mcp",
+  version: "0.1.0",
+});
+
+server.tool(
+  "foundry_read_obsidian_notes",
+  "Read markdown notes from the Obsidian Honkonomicon vault. Parses YAML frontmatter and renders content as HTML with Obsidian-flavored extensions (wikilinks, embeds, callouts). Use filter_type to narrow by document type (journal, actor, npc, item).",
+  readObsidianSchema.shape,
+  async (input) => {
+    if (!VAULT_PATH) {
+      return {
+        content: [{ type: "text", text: "Error: VAULT_PATH environment variable is not set." }],
+        isError: true,
+      };
+    }
+
+    const notes = await readObsidianNotes(input, VAULT_PATH, MAX_FILES, MAX_CONTENT_CHARS);
+    return {
+      content: [{ type: "text", text: JSON.stringify(notes, null, 2) }],
+    };
+  },
+);
+
+server.tool(
+  "foundry_create_journal_entries",
+  "Generate a Foundry VTT import payload for journal entries. Returns JSON matching the foundry-mcp module's importPayload() format. Paste the output into Foundry's import dialog to create the entries.",
+  createJournalsSchema.shape,
+  async (input) => {
+    const payload = buildImportPayload(input);
+    return {
+      content: [{ type: "text", text: JSON.stringify(payload, null, 2) }],
+    };
+  },
+);
+
+server.tool(
+  "foundry_list_journals",
+  "List existing journal entries in the Foundry VTT world. Currently a stub — requires a running game session.",
+  listJournalsSchema.shape,
+  async () => {
+    return {
+      content: [{ type: "text", text: LIST_JOURNALS_UNAVAILABLE }],
+    };
+  },
+);
+
+const transport = new StdioServerTransport();
+await server.connect(transport);

--- a/mcp-server/src/server.ts
+++ b/mcp-server/src/server.ts
@@ -6,8 +6,14 @@ import { createJournalsSchema, buildImportPayload } from "./tools/createJournals
 import { listJournalsSchema, LIST_JOURNALS_UNAVAILABLE } from "./tools/listJournals.js";
 
 const VAULT_PATH = process.env.VAULT_PATH || "";
-const MAX_FILES = parseInt(process.env.MAX_FILES || "500", 10);
-const MAX_CONTENT_CHARS = parseInt(process.env.MAX_CONTENT_CHARS || "20000", 10);
+const parsedMaxFiles = parseInt(process.env.MAX_FILES || "500", 10);
+const parsedMaxContent = parseInt(process.env.MAX_CONTENT_CHARS || "20000", 10);
+const MAX_FILES = Number.isNaN(parsedMaxFiles) || parsedMaxFiles <= 0 ? 500 : parsedMaxFiles;
+const MAX_CONTENT_CHARS = Number.isNaN(parsedMaxContent) || parsedMaxContent <= 0 ? 20000 : parsedMaxContent;
+
+if (!VAULT_PATH) {
+  console.error("[foundry-mcp] WARNING: VAULT_PATH is not set. foundry_read_obsidian_notes will fail.");
+}
 
 const server = new McpServer({
   name: "foundry-mcp",
@@ -16,7 +22,7 @@ const server = new McpServer({
 
 server.tool(
   "foundry_read_obsidian_notes",
-  "Read markdown notes from the Obsidian Honkonomicon vault. Parses YAML frontmatter and renders content as HTML with Obsidian-flavored extensions (wikilinks, embeds, callouts). Use filter_type to narrow by document type (journal, actor, npc, item).",
+  "Read markdown notes from the configured Obsidian vault. Parses YAML frontmatter and renders content as HTML with Obsidian-flavored extensions (wikilinks, embeds, callouts). Use filter_type to narrow by document type (journal, actor, npc, item).",
   readObsidianSchema.shape,
   async (input) => {
     if (!VAULT_PATH) {
@@ -26,16 +32,27 @@ server.tool(
       };
     }
 
-    const notes = await readObsidianNotes(input, VAULT_PATH, MAX_FILES, MAX_CONTENT_CHARS);
-    return {
-      content: [{ type: "text", text: JSON.stringify(notes, null, 2) }],
-    };
+    try {
+      const { notes, skipped } = await readObsidianNotes(input, VAULT_PATH, MAX_FILES, MAX_CONTENT_CHARS);
+      const summary = skipped > 0
+        ? `\n\n---\n${skipped} file(s) skipped due to read/parse errors (see server stderr for details).`
+        : "";
+      return {
+        content: [{ type: "text", text: JSON.stringify(notes, null, 2) + summary }],
+      };
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      return {
+        content: [{ type: "text", text: `Error reading vault at ${VAULT_PATH}: ${msg}` }],
+        isError: true,
+      };
+    }
   },
 );
 
 server.tool(
   "foundry_create_journal_entries",
-  "Generate a Foundry VTT import payload for journal entries. Returns JSON matching the foundry-mcp module's importPayload() format. Paste the output into Foundry's import dialog to create the entries.",
+  "Generate a Foundry VTT import payload for journal entries. Returns JSON matching the foundry-mcp module's importPayload() schema. Feed the output to the foundry-mcp module's import function to create the entries.",
   createJournalsSchema.shape,
   async (input) => {
     const payload = buildImportPayload(input);
@@ -57,4 +74,9 @@ server.tool(
 );
 
 const transport = new StdioServerTransport();
-await server.connect(transport);
+try {
+  await server.connect(transport);
+} catch (err) {
+  console.error(`[foundry-mcp] Failed to start MCP server: ${(err as Error).message}`);
+  process.exit(1);
+}

--- a/mcp-server/src/tools/createJournals.ts
+++ b/mcp-server/src/tools/createJournals.ts
@@ -27,7 +27,7 @@ export function buildImportPayload(input: CreateJournalsInput): ImportPayload {
         {
           name: doc.name,
           type: "text",
-          text: { content: doc.content, format: 1 },
+          text: { content: doc.content, format: 1 }, // CONST.JOURNAL_ENTRY_PAGE_FORMATS.HTML
         },
       ],
     },

--- a/mcp-server/src/tools/createJournals.ts
+++ b/mcp-server/src/tools/createJournals.ts
@@ -1,0 +1,37 @@
+import { z } from "zod";
+import type { ImportPayload, FoundryDocument } from "../types.js";
+
+export const createJournalsSchema = z.object({
+  documents: z
+    .array(
+      z.object({
+        name: z.string().describe("Journal entry name"),
+        content: z.string().describe("HTML content for the journal page"),
+        folder: z.string().optional().describe("Foundry folder name"),
+        pack: z.string().optional().describe("Target compendium pack ID"),
+      }),
+    )
+    .describe("Array of journal entries to create"),
+});
+
+export type CreateJournalsInput = z.infer<typeof createJournalsSchema>;
+
+export function buildImportPayload(input: CreateJournalsInput): ImportPayload {
+  const documents: FoundryDocument[] = input.documents.map((doc) => ({
+    type: "JournalEntry",
+    pack: doc.pack,
+    data: {
+      name: doc.name,
+      folder: doc.folder,
+      pages: [
+        {
+          name: doc.name,
+          type: "text",
+          text: { content: doc.content, format: 1 },
+        },
+      ],
+    },
+  }));
+
+  return { documents };
+}

--- a/mcp-server/src/tools/listJournals.ts
+++ b/mcp-server/src/tools/listJournals.ts
@@ -1,0 +1,11 @@
+import { z } from "zod";
+
+export const listJournalsSchema = z.object({});
+
+export const LIST_JOURNALS_UNAVAILABLE =
+  "Listing existing journal entries requires a running Foundry VTT game session. " +
+  "The Forge does not expose Foundry's document API from outside the browser.\n\n" +
+  "To see existing journals:\n" +
+  "1. Open your Foundry world in the browser\n" +
+  "2. Use the Journal tab in the sidebar\n" +
+  "3. Or run `game.journal.contents.map(j => ({ id: j.id, name: j.name }))` in the browser console";

--- a/mcp-server/src/tools/readObsidian.ts
+++ b/mcp-server/src/tools/readObsidian.ts
@@ -1,11 +1,15 @@
 import { readFile } from "node:fs/promises";
-import { relative, extname, basename } from "node:path";
+import { join, resolve, relative, extname, basename } from "node:path";
 import matter from "gray-matter";
 import { z } from "zod";
 import { walkVaultFiles } from "../vault/walker.js";
-
 import { renderMarkdown } from "../vault/markdown.js";
 import type { VaultNote } from "../types.js";
+
+export interface ReadObsidianResult {
+  notes: VaultNote[];
+  skipped: number;
+}
 
 export const readObsidianSchema = z.object({
   paths: z
@@ -15,7 +19,7 @@ export const readObsidianSchema = z.object({
   filter_type: z
     .string()
     .optional()
-    .describe('Filter by frontmatter type: "journal", "actor", "npc", "item"'),
+    .describe('Filter by frontmatter type (case-insensitive). Common values: journal, actor, npc, item'),
   include_content: z
     .boolean()
     .default(true)
@@ -29,17 +33,24 @@ export async function readObsidianNotes(
   vaultPath: string,
   maxFiles: number,
   maxContentChars: number,
-): Promise<VaultNote[]> {
+): Promise<ReadObsidianResult> {
+  const resolvedVault = resolve(vaultPath);
   let filePaths: string[];
 
   if (input.paths && input.paths.length > 0) {
-    const { join } = await import("node:path");
-    filePaths = input.paths.map((p) => join(vaultPath, p));
+    filePaths = input.paths.map((p) => {
+      const resolved = resolve(join(vaultPath, p));
+      if (!resolved.startsWith(resolvedVault + "/")) {
+        throw new Error(`Path traversal blocked: ${p}`);
+      }
+      return resolved;
+    });
   } else {
     filePaths = await walkVaultFiles(vaultPath, maxFiles);
   }
 
   const results: VaultNote[] = [];
+  let skipped = 0;
 
   for (const filePath of filePaths) {
     try {
@@ -72,10 +83,11 @@ export async function readObsidianNotes(
 
       results.push(note);
     } catch (err) {
+      skipped++;
       const msg = err instanceof Error ? err.message : String(err);
       console.error(`[foundry-mcp] Skipping ${filePath}: ${msg}`);
     }
   }
 
-  return results;
+  return { notes: results, skipped };
 }

--- a/mcp-server/src/tools/readObsidian.ts
+++ b/mcp-server/src/tools/readObsidian.ts
@@ -1,0 +1,81 @@
+import { readFile } from "node:fs/promises";
+import { relative, extname, basename } from "node:path";
+import matter from "gray-matter";
+import { z } from "zod";
+import { walkVaultFiles } from "../vault/walker.js";
+
+import { renderMarkdown } from "../vault/markdown.js";
+import type { VaultNote } from "../types.js";
+
+export const readObsidianSchema = z.object({
+  paths: z
+    .array(z.string())
+    .optional()
+    .describe("Specific file paths relative to the vault root. If omitted, scans the entire vault."),
+  filter_type: z
+    .string()
+    .optional()
+    .describe('Filter by frontmatter type: "journal", "actor", "npc", "item"'),
+  include_content: z
+    .boolean()
+    .default(true)
+    .describe("Whether to include rendered HTML content in results"),
+});
+
+export type ReadObsidianInput = z.infer<typeof readObsidianSchema>;
+
+export async function readObsidianNotes(
+  input: ReadObsidianInput,
+  vaultPath: string,
+  maxFiles: number,
+  maxContentChars: number,
+): Promise<VaultNote[]> {
+  let filePaths: string[];
+
+  if (input.paths && input.paths.length > 0) {
+    const { join } = await import("node:path");
+    filePaths = input.paths.map((p) => join(vaultPath, p));
+  } else {
+    filePaths = await walkVaultFiles(vaultPath, maxFiles);
+  }
+
+  const results: VaultNote[] = [];
+
+  for (const filePath of filePaths) {
+    try {
+      const raw = await readFile(filePath, "utf-8");
+      const { data, content: bodyContent } = matter(raw);
+      const type = String(data.type || "journal").toLowerCase();
+
+      if (input.filter_type && type !== input.filter_type.toLowerCase()) {
+        continue;
+      }
+
+      const ext = extname(filePath);
+      const name = (data.title as string) || (data.name as string) || basename(filePath, ext);
+      const relPath = relative(vaultPath, filePath);
+
+      const note: VaultNote = {
+        path: relPath,
+        name,
+        type,
+        frontmatter: data,
+      };
+
+      if (input.include_content) {
+        const clipped =
+          bodyContent.length > maxContentChars
+            ? bodyContent.slice(0, maxContentChars) + "\n…[truncated]"
+            : bodyContent;
+        note.content = renderMarkdown(clipped);
+      }
+
+      results.push(note);
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      console.error(`[foundry-mcp] Skipping ${filePath}: ${msg}`);
+    }
+  }
+
+  return results;
+}

--- a/mcp-server/src/types.ts
+++ b/mcp-server/src/types.ts
@@ -1,0 +1,32 @@
+export interface FoundryDocument {
+  type: "JournalEntry" | "Actor" | "Item";
+  pack?: string;
+  data: Record<string, unknown>;
+}
+
+export interface ImportPayload {
+  compendiums?: CompendiumDef[];
+  documents: FoundryDocument[];
+  assets?: AssetDef[];
+}
+
+export interface CompendiumDef {
+  name: string;
+  label: string;
+  type: string;
+  package?: string;
+}
+
+export interface AssetDef {
+  filename: string;
+  data: string;
+  folder?: string;
+}
+
+export interface VaultNote {
+  path: string;
+  name: string;
+  type: string;
+  frontmatter: Record<string, unknown>;
+  content?: string;
+}

--- a/mcp-server/src/vault/frontmatter.ts
+++ b/mcp-server/src/vault/frontmatter.ts
@@ -1,0 +1,64 @@
+import { basename, extname } from "node:path";
+import type { FoundryDocument } from "../types.js";
+
+interface FrontmatterInput {
+  filePath: string;
+  data: Record<string, unknown>;
+  content: string;
+}
+
+export function mapFrontmatterToDocument({
+  filePath,
+  data,
+  content,
+}: FrontmatterInput): FoundryDocument | null {
+  const type = String(data.type || "journal").toLowerCase();
+  const ext = extname(filePath);
+  const name =
+    (data.title as string) || (data.name as string) || basename(filePath, ext);
+  const pack =
+    (data.compendium as string) || (data.pack as string) || undefined;
+  const foundryId = (data.foundryId as string) || (data._id as string);
+
+  if (type === "npc" || type === "actor") {
+    return {
+      type: "Actor",
+      pack,
+      data: {
+        _id: foundryId,
+        name,
+        type: "npc",
+        system: data.system || {},
+        notes: { value: content },
+      },
+    };
+  }
+
+  if (type === "item") {
+    return {
+      type: "Item",
+      pack,
+      data: {
+        _id: foundryId,
+        name,
+        type: (data.itemType as string) || "loot",
+        system: data.system || {},
+        description: { value: content },
+      },
+    };
+  }
+
+  if (type === "journal" || type === "journalentry") {
+    return {
+      type: "JournalEntry",
+      pack,
+      data: {
+        _id: foundryId,
+        name,
+        content,
+      },
+    };
+  }
+
+  return null;
+}

--- a/mcp-server/src/vault/frontmatter.ts
+++ b/mcp-server/src/vault/frontmatter.ts
@@ -55,7 +55,13 @@ export function mapFrontmatterToDocument({
       data: {
         _id: foundryId,
         name,
-        content,
+        pages: [
+          {
+            name,
+            type: "text",
+            text: { content, format: 1 }, // CONST.JOURNAL_ENTRY_PAGE_FORMATS.HTML
+          },
+        ],
       },
     };
   }

--- a/mcp-server/src/vault/markdown.ts
+++ b/mcp-server/src/vault/markdown.ts
@@ -1,0 +1,107 @@
+import { Marked, type TokenizerExtension, type RendererExtension } from "marked";
+
+export function escapeHtml(str: string): string {
+  return str
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;")
+    .replace(/'/g, "&#39;");
+}
+
+const UNSAFE_TAGS =
+  /<\s*\/?\s*(script|iframe|object|embed|form|link|meta|style)\b[^>]*>/gi;
+const EVENT_ATTR =
+  /\s+on\w+\s*=\s*("[^"]*"|'[^']*'|[^\s>]*)/gi;
+const TAG_WITH_EVENT_HANDLER = /<([^>]*)\s+on\w+\s*=([^>]*)>/gi;
+
+export function sanitizeHtml(html: string): string {
+  return html
+    .replace(UNSAFE_TAGS, "")
+    .replace(TAG_WITH_EVENT_HANDLER, (match) =>
+      match.replace(EVENT_ATTR, "")
+    );
+}
+
+const wikilink: TokenizerExtension & RendererExtension = {
+  name: "wikilink",
+  level: "inline",
+  start(src: string) {
+    return src.indexOf("[[");
+  },
+  tokenizer(src: string) {
+    const match = src.match(/^\[\[([^\]|]+?)(?:\|([^\]]+?))?\]\]/);
+    if (match) {
+      return {
+        type: "wikilink",
+        raw: match[0],
+        target: match[1].trim(),
+        display: (match[2] || match[1]).trim(),
+      };
+    }
+    return undefined;
+  },
+  renderer(token) {
+    const t = token as unknown as { target: string; display: string };
+    return `<a class="foundry-mcp-wikilink" data-target="${escapeHtml(t.target)}">${escapeHtml(t.display)}</a>`;
+  },
+};
+
+const embed: TokenizerExtension & RendererExtension = {
+  name: "embed",
+  level: "inline",
+  start(src: string) {
+    return src.indexOf("![[");
+  },
+  tokenizer(src: string) {
+    const match = src.match(/^!\[\[([^\]]+?)\]\]/);
+    if (match) {
+      return {
+        type: "embed",
+        raw: match[0],
+        target: match[1].trim(),
+      };
+    }
+    return undefined;
+  },
+  renderer(token) {
+    const t = token as unknown as { target: string };
+    const safe = escapeHtml(t.target);
+    return `<div class="foundry-mcp-embed" data-target="${safe}">[Embedded: ${safe}]</div>`;
+  },
+};
+
+const CALLOUT_TYPES = new Set([
+  "note", "warning", "tip", "info", "danger", "example",
+  "quote", "abstract", "success", "question", "failure", "bug",
+]);
+
+const marked = new Marked();
+
+marked.use({
+  extensions: [embed, wikilink],
+  renderer: {
+    blockquote({ text }: { text: string }) {
+      const calloutMatch = text.match(/^\[!([\w-]+)\][^\S\n]*(.*)/);
+      if (calloutMatch) {
+        const type = calloutMatch[1].toLowerCase();
+        if (CALLOUT_TYPES.has(type)) {
+          const customTitle = calloutMatch[2]?.trim();
+          const title =
+            customTitle || type.charAt(0).toUpperCase() + type.slice(1);
+          const bodyText = text
+            .slice(calloutMatch[0].length)
+            .replace(/^\n/, "")
+            .trim();
+          const bodyHtml = bodyText ? (marked.parse(bodyText) as string) : "";
+          return `<div class="foundry-mcp-callout callout-${escapeHtml(type)}"><p class="callout-title">${escapeHtml(title)}</p>${bodyHtml}</div>`;
+        }
+      }
+      return `<blockquote>\n${text}</blockquote>\n`;
+    },
+  },
+});
+
+export function renderMarkdown(content: string): string {
+  return sanitizeHtml(marked.parse(content) as string);
+}

--- a/mcp-server/src/vault/markdown.ts
+++ b/mcp-server/src/vault/markdown.ts
@@ -93,7 +93,7 @@ marked.use({
             .slice(calloutMatch[0].length)
             .replace(/^\n/, "")
             .trim();
-          const bodyHtml = bodyText ? (marked.parse(bodyText) as string) : "";
+          const bodyHtml = bodyText ? String(marked.parse(bodyText)) : "";
           return `<div class="foundry-mcp-callout callout-${escapeHtml(type)}"><p class="callout-title">${escapeHtml(title)}</p>${bodyHtml}</div>`;
         }
       }
@@ -103,5 +103,5 @@ marked.use({
 });
 
 export function renderMarkdown(content: string): string {
-  return sanitizeHtml(marked.parse(content) as string);
+  return sanitizeHtml(String(marked.parse(content)));
 }

--- a/mcp-server/src/vault/walker.ts
+++ b/mcp-server/src/vault/walker.ts
@@ -1,0 +1,31 @@
+import { readdir } from "node:fs/promises";
+import { join } from "node:path";
+
+const DEFAULT_MAX_FILES = 500;
+
+export async function walkVaultFiles(
+  rootDir: string,
+  maxFiles: number = DEFAULT_MAX_FILES
+): Promise<string[]> {
+  const results: string[] = [];
+  const stack: string[] = [rootDir];
+
+  while (stack.length > 0 && results.length < maxFiles) {
+    const current = stack.pop()!;
+    const entries = await readdir(current, { withFileTypes: true });
+
+    for (const entry of entries) {
+      if (results.length >= maxFiles) break;
+      const entryPath = join(current, entry.name);
+
+      if (entry.isDirectory()) {
+        if (entry.name.startsWith(".")) continue;
+        stack.push(entryPath);
+      } else if (entry.isFile() && entry.name.endsWith(".md")) {
+        results.push(entryPath);
+      }
+    }
+  }
+
+  return results;
+}

--- a/mcp-server/src/vault/walker.ts
+++ b/mcp-server/src/vault/walker.ts
@@ -12,7 +12,14 @@ export async function walkVaultFiles(
 
   while (stack.length > 0 && results.length < maxFiles) {
     const current = stack.pop()!;
-    const entries = await readdir(current, { withFileTypes: true });
+
+    let entries;
+    try {
+      entries = await readdir(current, { withFileTypes: true });
+    } catch (err) {
+      console.error(`[foundry-mcp] Cannot read directory ${current}: ${(err as Error).message}`);
+      continue;
+    }
 
     for (const entry of entries) {
       if (results.length >= maxFiles) break;

--- a/mcp-server/tsconfig.json
+++ b/mcp-server/tsconfig.json
@@ -1,0 +1,23 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "baseUrl": ".",
+    "paths": {
+      "@modelcontextprotocol/sdk/*": [
+        "node_modules/@modelcontextprotocol/sdk/dist/esm/*"
+      ]
+    },
+    "strict": true,
+    "esModuleInterop": true,
+    "forceConsistentCasingInFileNames": true,
+    "skipLibCheck": true,
+    "outDir": "dist",
+    "rootDir": "src",
+    "resolveJsonModule": true,
+    "types": ["node"]
+  },
+  "include": ["src/**/*.ts"],
+  "exclude": ["dist", "node_modules"]
+}


### PR DESCRIPTION
## Summary

- Adds `mcp-server/` — a TypeScript MCP server (stdio transport, `@modelcontextprotocol/sdk`) with three tools:
  - `foundry_read_obsidian_notes` — walks the Obsidian vault, parses YAML frontmatter, renders markdown with Obsidian-flavored extensions (wikilinks, embeds, callouts)
  - `foundry_create_journal_entries` — generates `importPayload` JSON matching the `foundry-mcp` module's expected schema (documents with pages, compendium targeting)
  - `foundry_list_journals` — stub explaining the live-game-session requirement
- Vault logic (walker, frontmatter mapping, markdown rendering) ported from `obsidian-agent/src/` to TypeScript
- Adds `.gitignore` for `node_modules/`, `mcp-server/dist/`, `.DS_Store`
- Includes handoff doc from the OpenClaw session that scoped this work

## Registration (post-merge)

Add to `~/.config/opencode/opencode.json` under `mcp`:
```json
"foundry": {
  "command": ["node", "/path/to/foundryVTT-MCP/mcp-server/dist/server.js"],
  "enabled": true,
  "environment": { "VAULT_PATH": "/path/to/Honkonomicon" }
}
```
Add `foundry` to `SWITCHBOARD_INCLUDE` in both `opencode.json` and `openclaw.json`.

## Test plan

- [x] `cd mcp-server && npm install && npm run build` — clean tsc compilation
- [x] MCP tool listing returns all 3 tools via SDK client
- [x] `foundry_read_obsidian_notes` reads Honkonomicon vault, returns parsed notes with frontmatter
- [x] `foundry_create_journal_entries` generates valid `ImportPayload` JSON with pages structure
- [ ] Verify payload accepted by Foundry import dialog (manual, post-deploy)

🤖 Generated with [Claude Code](https://claude.com/claude-code)